### PR TITLE
Use github.token to avoid rate limits

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - main
+      - '**'
   workflow_dispatch: 
   schedule:
     - cron: '0 0 * * *'

--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ runs:
       run: . <(curl -Lf https://raw.githubusercontent.com/DefangLabs/defang/main/src/bin/install || echo return $?)
       env:
         DEFANG_INSTALL_VERSION: ${{ inputs['cli-version'] }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # avoid rate-limits
+        GH_TOKEN: ${{ github.token }} # avoid rate-limits
 
     - name: Login to Defang
       shell: bash


### PR DESCRIPTION
`secrets.GITHUB_TOKEN` didn't work