### PR TITLE
Add command input param

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,9 +31,9 @@ jobs:
         cwd: "./test"
         compose-files: "compose.yaml compose.prod.yaml"
         mode: "staging"
+        command: "compose up --dry-run"
       env:
         DEFANG_GH_ACTION_TEST_MESSAGE: ${{ secrets.MESSAGE }}
-        DEFANG_INTERNAL_TEST: dfng-test
 
     - name: Deploy-Empty-Params
       uses: ./
@@ -44,8 +44,7 @@ jobs:
         cwd: "./test"
         compose-files: ""
         mode: ""
-      env:
-        DEFANG_INTERNAL_TEST: dfng-test
+        command: "compose up --dry-run --project-name github-action-test"
 
     - name: Teardown
       run: defang config rm DEFANG_GH_ACTION_TEST_MESSAGE

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
         config-env-vars: "DEFANG_GH_ACTION_TEST_MESSAGE"
         cwd: "./test"
         compose-files: "compose.yaml compose.prod.yaml"
-        mode: "staging"
+        mode: ""
         command: "compose up --dry-run"
       env:
         DEFANG_GH_ACTION_TEST_MESSAGE: ${{ secrets.MESSAGE }}
@@ -39,11 +39,10 @@ jobs:
       uses: ./
       continue-on-error: true # Ignore dry run error
       with:
-        cli-version: v0.5.40
         config-env-vars: ""
         cwd: "./test"
         compose-files: ""
-        mode: ""
+        mode: "staging"
         command: "compose up --dry-run --project-name github-action-test"
 
     - name: Teardown

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
 
 ### Managing Config Values
 
-Defang allows you to [securely manage configuration values](https://docs.defang.io/docs/concepts/configuration). You can store your config using [GitHub Actions Secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) and then pass them through to the Defang action. 
+Defang allows you to [securely manage configuration values](https://docs.defang.io/docs/concepts/configuration). You can store your config using [GitHub Actions Secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) and then pass them through to the Defang action.
 
 To publish a secret stored in GitHub to the cloud as a secure config value with defang, you need to do two things:
 
@@ -81,6 +81,23 @@ jobs:
       uses: DefangLabs/defang-github-action@v1.1.0
       with:
         cli-version: v0.5.38
+```
+
+### Customizing the Defang Command
+
+If you want to customize the Defang command that is run, you can specify it using the `command` input.
+This is useful if you want to run a command other than `compose up` or if you want to pass additional arguments to the command.
+
+```yaml
+jobs:
+  test:
+    # [...]
+    steps:
+      # [...]
+    - name: Deploy
+      uses: DefangLabs/defang-github-action@v1.1.0
+      with:
+        command: "compose up --project-name my-project"
 ```
 
 ### Full Example

--- a/action.yaml
+++ b/action.yaml
@@ -90,11 +90,6 @@ runs:
           params+=("--mode=${{ inputs['mode'] }}")
         fi
 
-        if [[ "${DEFANG_INTERNAL_TEST}" == "dfng-test" ]]; then
-          # `--dry-run` is used for testing as --mode flag is only available to the "compose up" command
-          params+=("--dry-run")
-        fi
-
         echo defang $COMMAND "${params[@]}"
         defang $COMMAND "${params[@]}"
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -59,7 +59,7 @@ runs:
 
     - name: Defang Config Set
       shell: bash
-      if: ${{ inputs['config-env-vars'] != "" }}
+      if: ${{ inputs['config-env-vars'] != '' }}
       run: |
         # Iterate over the sources and set the environment variables
         params=()
@@ -77,7 +77,7 @@ runs:
         CONFIG_ENV_VARS: ${{ inputs['config-env-vars'] }}
 
     - name: Defang ${{ inputs['command'] }}
-      if: ${{ inputs['command'] != "" }}
+      if: ${{ inputs['command'] != '' }}
       shell: bash
       working-directory: ${{ inputs.cwd }}
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -27,9 +27,13 @@ inputs:
     required: false
     default: ""
   provider:
-    description: "The cloud provider to deploy to. Options: 'aws', 'defang'"
+    description: "The cloud provider to deploy to. Options: 'aws', 'defang', 'digitalocean'"
     required: false
     default: "defang"
+  command:
+    description: "The command to run."
+    required: false
+    default: "compose up"
 
 runs:
   using: "composite"
@@ -55,6 +59,7 @@ runs:
 
     - name: Defang Config Set
       shell: bash
+      if: ${{ inputs['config-env-vars'] != "" }}
       run: |
         # Iterate over the sources and set the environment variables
         params=()
@@ -71,7 +76,8 @@ runs:
       env:
         CONFIG_ENV_VARS: ${{ inputs['config-env-vars'] }}
 
-    - name: Defang Compose Up
+    - name: Defang ${{ inputs['command'] }}
+      if: ${{ inputs['command'] != "" }}
       shell: bash
       working-directory: ${{ inputs.cwd }}
       run: |
@@ -85,10 +91,11 @@ runs:
         fi
 
         if [[ "${DEFANG_INTERNAL_TEST}" == "dfng-test" ]]; then
-          # `defang compose up --dry-run` is used for testing as --mode flag is only available to the "compose up" command
-          echo defang compose "${params[@]}" up --dry-run
-          defang compose "${params[@]}" up --dry-run
-        else
-          echo defang compose "${params[@]}" up
-          defang compose "${params[@]}" up
+          # `--dry-run` is used for testing as --mode flag is only available to the "compose up" command
+          params+=("--dry-run")
         fi
+
+        echo defang $COMMAND "${params[@]}"
+        defang $COMMAND "${params[@]}"
+      env:
+        COMMAND: ${{ inputs['command'] }}


### PR DESCRIPTION
Main reason was to be able to skip `defang compose up` for projects that use our Pulumi provider, eg. the portal. 

Fixes #10 