### PR TITLE
Auto-accept TOS for successful deployment

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -55,6 +55,7 @@ runs:
       shell: bash
       run: |
         defang login
+        defang terms --agree-tos
         defang whoami
 
     - name: Defang Config Set


### PR DESCRIPTION
During deployment via Github actions I see:

```
Error: you must agree to the terms of service first
```

Although I can deploy locally. Let me know if the above is the intended approach or maybe some explicit input into the action