### PR TITLE
Support Git ref in cli-version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,13 @@ jobs:
           DEFANG_GH_ACTION_TEST_ENV: "foo"
           DEFANG_GH_ACTION_TEST_MESSAGE: ${{ secrets.MESSAGE }}
 
+      - name: Deploy from Git ref
+        uses: ./
+        with:
+          cli-version: main
+          cwd: "./test"
+          command: "config help"
+
       - name: Deploy-Empty-Params
         uses: ./
         continue-on-error: true # Ignore dry run error

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,10 +4,7 @@ on:
   push:
     branches:
       - main
-      - "**"
   pull_request:
-    branches:
-      - "**"
   workflow_dispatch:
   # schedule:
   #   - cron: "0 0 * * *" # daily at midnight

--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ jobs:
 
 ### Specifying the CLI Version
 
-If you want to use a specific version of the Defang CLI, you can specify it using the `cli-version` input. Specify a version number, or `nightly` to use the nightly CLI build. Note that the nightly builds have only undergone limited automated testing and should be considered unstable.
+If you want to use a specific version of the Defang CLI, you can specify it using the `cli-version` input.
+Specify a version number (with or without `v`), or `nightly` to use the nightly CLI build.
+Note that the nightly builds have only undergone limited automated testing and should be considered unstable.
+You can also pass any Git ref (branch name like `main` or commit SHA) to build the CLI from source using `go`.
 
 ```yaml
 jobs:
@@ -88,21 +91,7 @@ jobs:
       - name: Deploy
         uses: DefangLabs/defang-github-action@v2
         with:
-          cli-version: v3.5.2
-```
-
-You can also pass any Git ref (branch name or commit SHA) to build the CLI from source:
-
-```yaml
-jobs:
-  test:
-    # [...]
-    steps:
-      # [...]
-      - name: Deploy
-        uses: DefangLabs/defang-github-action@v2
-        with:
-          cli-version: main
+          cli-version: v3.5.2 # or 3.5.2 or nightly or main or a commit SHA
 ```
 
 ### Customizing the Defang Command

--- a/README.md
+++ b/README.md
@@ -88,7 +88,21 @@ jobs:
       - name: Deploy
         uses: DefangLabs/defang-github-action@v2
         with:
-          cli-version: v2.10.0
+          cli-version: v3.5.2
+```
+
+You can also pass any Git ref (branch name or commit SHA) to build the CLI from source:
+
+```yaml
+jobs:
+  test:
+    # [...]
+    steps:
+      # [...]
+      - name: Deploy
+        uses: DefangLabs/defang-github-action@v2
+        with:
+          cli-version: main
 ```
 
 ### Customizing the Defang Command
@@ -134,7 +148,7 @@ jobs:
       - name: Deploy
         uses: DefangLabs/defang-github-action@v2
         with:
-          cli-version: v2.10.0
+          cli-version: v3.5.2
           config-env-vars: "API_KEY DB_CONNECTION_STRING"
           cwd: "./test"
           compose-files: "./docker-compose.yaml"

--- a/action.yaml
+++ b/action.yaml
@@ -63,7 +63,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # If cli-version is a Git ref (not empty, not "nightly", and no dots, eg. no "v1.2.3"),
+    # build the CLI from source instead of downloading a release.
     - name: Checkout CLI repository
+      id: checkout-cli
       if: inputs.cli-version != '' && inputs.cli-version != 'nightly' && !contains(inputs.cli-version, '.')
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -72,13 +75,13 @@ runs:
         path: defang-cli
 
     - name: Setup Go
-      if: inputs.cli-version != '' && inputs.cli-version != 'nightly' && !contains(inputs.cli-version, '.')
+      if: steps.checkout-cli.outcome == 'success'
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: defang-cli/src/go.mod
 
     - name: Build CLI from source
-      if: inputs.cli-version != '' && inputs.cli-version != 'nightly' && !contains(inputs.cli-version, '.')
+      if: steps.checkout-cli.outcome == 'success'
       shell: bash
       run: cd defang-cli/src && go build -o "$RUNNER_TOOL_CACHE/defang" ./cmd/cli && echo "$RUNNER_TOOL_CACHE" >> "$GITHUB_PATH"
 

--- a/action.yaml
+++ b/action.yaml
@@ -79,6 +79,7 @@ runs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: defang-cli/src/go.mod
+        cache-dependency-path: defang-cli/src/go.sum
 
     - name: Build CLI from source
       if: steps.checkout-cli.outcome == 'success'

--- a/action.yaml
+++ b/action.yaml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   cli-version:
-    description: "The version of the Defang CLI to use. Defaults to the latest stable release."
+    description: "The version or Git ref of the Defang CLI to use. Defaults to the latest stable release."
     required: false
     default: ""
   config-env-vars:
@@ -63,6 +63,25 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout CLI repository
+      if: inputs.cli-version != '' && inputs.cli-version != 'nightly' && !contains(inputs.cli-version, '.')
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: DefangLabs/defang
+        ref: ${{ inputs.cli-version }}
+        path: defang-cli
+
+    - name: Setup Go
+      if: inputs.cli-version != '' && inputs.cli-version != 'nightly' && !contains(inputs.cli-version, '.')
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: defang-cli/src/go.mod
+
+    - name: Build CLI from source
+      if: inputs.cli-version != '' && inputs.cli-version != 'nightly' && !contains(inputs.cli-version, '.')
+      shell: bash
+      run: cd defang-cli/src && go build -o "$RUNNER_TOOL_CACHE/defang" ./cmd/cli && echo "$RUNNER_TOOL_CACHE" >> "$GITHUB_PATH"
+
     - name: Install defang
       shell: bash
       run: |


### PR DESCRIPTION
Allows Git ref like `main` in `cli-version` (needed for cli-smoketests)