### PR TITLE
Unset config-env-vars and config-vars-init-random

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -184,6 +184,8 @@ runs:
           y|Y|yes|Yes|YES|true|True|TRUE|on|On|ON|1) params+=("--allow-upgrade") ;;
         esac
 
+        unset ${{ inputs['config-env-vars'] }} ${{ inputs['config-vars-init-random'] }} dont_complain_on_empty
+
         echo defang $COMMAND "${params[@]}"
         output=$(defang $COMMAND "${params[@]}" | tee /dev/stderr)
         echo "stdout<<DEFANG_EOF" >> "$GITHUB_OUTPUT"

--- a/action.yaml
+++ b/action.yaml
@@ -184,7 +184,10 @@ runs:
           y|Y|yes|Yes|YES|true|True|TRUE|on|On|ON|1) params+=("--allow-upgrade") ;;
         esac
 
-        unset ${{ inputs['config-env-vars'] }} ${{ inputs['config-vars-init-random'] }} dont_complain_on_empty
+        # Unset config vars to avoid Defang CLI warning user that config from shell env is ignored
+        for var in ${{ inputs['config-env-vars'] }} ${{ inputs['config-vars-init-random'] }}; do
+          unset "$var"
+        done
 
         echo defang $COMMAND "${params[@]}"
         output=$(defang $COMMAND "${params[@]}" | tee /dev/stderr)

--- a/action.yaml
+++ b/action.yaml
@@ -185,9 +185,7 @@ runs:
         esac
 
         # Unset config vars to avoid Defang CLI warning user that config from shell env is ignored
-        for var in ${{ inputs['config-env-vars'] }} ${{ inputs['config-vars-init-random'] }}; do
-          unset "$var"
-        done
+        unset $CONFIG_ENV_VARS_INIT_RANDOM $CONFIG_ENV_VARS dont_complain_on_empty
 
         echo defang $COMMAND "${params[@]}"
         output=$(defang $COMMAND "${params[@]}" | tee /dev/stderr)
@@ -197,3 +195,6 @@ runs:
       env:
         COMMAND: ${{ inputs['command'] }}
         COMPOSE_FILES: ${{ inputs['compose-files'] }}
+        CONFIG_ENV_VARS: ${{ inputs['config-env-vars'] }}
+        CONFIG_ENV_VARS_INIT_RANDOM: ${{ inputs['config-vars-init-random'] }}
+


### PR DESCRIPTION
Unset specific input variables in the action script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated environment-variable handling so the Defang command no longer emits warnings about shell-provided configuration being ignored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/defang-github-action/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->