### PR TITLE
Deprecate mode and provider inputs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,6 @@ jobs:
           compose-files: |
             compose.yaml
             compose.prod.yaml
-          mode: ""
           command: "compose help"
         env:
           DEFANG_GH_ACTION_TEST_ENV: "foo"
@@ -53,7 +52,6 @@ jobs:
           config-env-vars: ""
           cwd: "./test"
           compose-files: ""
-          mode: "staging"
           verbose: true
           command: "compose up --dry-run --project-name github-action-test"
 

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ jobs:
           config-env-vars: "API_KEY DB_CONNECTION_STRING"
           cwd: "./test"
           compose-files: "./docker-compose.yaml"
-          mode: "staging"
-          provider: "aws"
+          mode: "staging" # deprecated in favor of stack:
+          provider: "aws" # deprecated in favor of stack:
           stack: "production"
           command: "compose up"
           verbose: true

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ jobs:
           config-env-vars: "API_KEY DB_CONNECTION_STRING"
           cwd: "./test"
           compose-files: "./docker-compose.yaml"
-          mode: "staging" # deprecated in favor of stack:
-          provider: "aws" # deprecated in favor of stack:
+          mode: "balanced" # deprecated in favor of stack:
+          provider: "aws"  # deprecated in favor of stack:
           stack: "production"
           command: "compose up"
           verbose: true

--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ inputs:
     required: false
     default: "."
   mode:
-    description: "The deployment mode. Options: 'affordable', 'balanced', 'high-availability'"
+    description: "The deployment mode. Options: 'affordable', 'balanced', 'high-availability'. Deprecated in favor of stack:"
     required: false
     default: ""
   stack:
@@ -47,7 +47,7 @@ inputs:
     required: false
     default: ""
   provider:
-    description: "The cloud provider to deploy to. Options: 'aws', 'defang', 'digitalocean', 'gcp'. If not specified, the CLI will determine the appropriate provider."
+    description: "The cloud provider to deploy to. Options: 'aws', 'azure', 'digitalocean', 'gcp'. If not specified, the CLI will determine the appropriate provider. Deprecated in favor of stack:"
     required: false
     default: ""
   verbose:


### PR DESCRIPTION
Mark 'mode' and 'provider' as deprecated in favor of 'stack'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Marked the `mode` and `provider` inputs as deprecated in favor of `stack`.
  - Updated documented provider options and refreshed workflow examples to include the deprecation notes and new example values.

- **Tests**
  - Updated workflow scenarios to stop supplying the deprecated `mode` input during compose command runs, keeping other inputs unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->