### PR TITLE
feat: add env-file input for compose interpolation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,5 +55,23 @@ jobs:
           verbose: true
           command: "compose up --dry-run --project-name github-action-test"
 
+      - name: Deploy with env-file
+        id: env-file-test
+        uses: ./
+        continue-on-error: true # Ignore dry run error
+        with:
+          cwd: "./test"
+          compose-files: "compose.envfile.yaml"
+          env-file: "action.env"
+          command: "compose config --project-name github-action-test"
+
+      - name: Verify env-file interpolation
+        shell: bash
+        run: |
+          echo "${STDOUT}" | grep -q "hello-from-env-file" \
+            || { echo "expected env-file value not found in output"; exit 1; }
+        env:
+          STDOUT: ${{ steps.env-file-test.outputs.stdout }}
+
       - name: Teardown
         run: defang config rm --project-name github-action-test DEFANG_GH_ACTION_TEST_MESSAGE

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ jobs:
           DB_CONNECTION_STRING: ${{ secrets.DB_CONNECTION_STRING }}
 ```
 
+### Using an Environment File
+
+By default, Defang loads a `.env` file next to your Compose file to resolve `${VARIABLE}` interpolation. To use a different environment file (or several), set the `env-file` input. This mirrors `docker compose --env-file` and, when set, replaces the default `.env`.
+
+```yaml
+jobs:
+  test:
+    # [...]
+    steps:
+      # [...]
+      - name: Deploy
+        uses: DefangLabs/defang-github-action@v2
+        with:
+          env-file: ".env.production"
+```
+
+Pass multiple files whitespace-delimited (`env-file: ".env .env.production"`); later files override earlier ones.
+
 ### Projects in a Subdirectory
 
 If your Compose file is in a different directory than your project root, you can specify the path to the project in the `cwd` input.

--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,10 @@ inputs:
     description: "The compose files to deploy. Format 'file1 file2 file3'"
     required: false
     default: ""
+  env-file:
+    description: "Environment file(s) used for compose interpolation instead of the default .env. Format 'file1 file2 file3'"
+    required: false
+    default: ""
   cwd:
     description: "The directory containing the compose file to deploy."
     required: false
@@ -111,6 +115,10 @@ runs:
         [ -n "${{ inputs['provider'] }}" ] && echo "DEFANG_PROVIDER=${{ inputs['provider'] }}" >> $GITHUB_ENV || true
         [ -n "${{ inputs['stack'] }}" ] && echo "DEFANG_STACK=${{ inputs['stack'] }}" >> $GITHUB_ENV || true
         [ -n "${{ inputs['project'] }}" ] && echo "COMPOSE_PROJECT_NAME=${{ inputs['project'] }}" >> $GITHUB_ENV || true
+        # The CLI reads COMPOSE_ENV_FILES (comma-separated) like docker compose; convert the space-separated input.
+        [ -n "$ENV_FILE" ] && echo "COMPOSE_ENV_FILES=$(echo "$ENV_FILE" | tr ' ' ',')" >> $GITHUB_ENV || true
+      env:
+        ENV_FILE: ${{ inputs['env-file'] }}
 
     - name: Login to Defang
       shell: bash

--- a/test/action.env
+++ b/test/action.env
@@ -1,0 +1,1 @@
+GREETING=hello-from-env-file

--- a/test/compose.envfile.yaml
+++ b/test/compose.envfile.yaml
@@ -1,0 +1,7 @@
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      GREETING: ${GREETING}


### PR DESCRIPTION
## What

Adds an `env-file` input so workflows can point Compose interpolation at a non-default environment file (e.g. `.env.production`), matching `docker compose --env-file`.

The input is mapped to the `COMPOSE_ENV_FILES` environment variable that the Defang CLI reads (whitespace-delimited input is converted to the comma-separated form the CLI expects), the same way `project` maps to `COMPOSE_PROJECT_NAME`. Using the env var means it applies to whatever `command` runs, not just `compose up`.

Depends on the CLI-side support in DefangLabs/defang#2178.

## Usage

```yaml
- uses: DefangLabs/defang-github-action@v2
  with:
    env-file: ".env.production"        # or: ".env .env.production"
```

## Changes

- `action.yaml`: new `env-file` input; set `COMPOSE_ENV_FILES` in the env-setup step.
- `README.md`: new "Using an Environment File" section.
- `.github/workflows/test.yaml` + `test/compose.envfile.yaml` + `test/action.env`: a step that runs `compose config` with `env-file` and asserts the interpolated value reaches the CLI output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw7j9FYnbChZJbYArxbhuo